### PR TITLE
mainfragmentのviewmodel作成

### DIFF
--- a/app/src/main/java/com/example/okhttp/model/XmlManager.kt
+++ b/app/src/main/java/com/example/okhttp/model/XmlManager.kt
@@ -1,9 +1,9 @@
 package com.example.okhttp.model
 
-import com.example.okhttp.model.Entity.Flag
-import com.example.okhttp.model.Entity.Visa
 import com.example.okhttp.R
 import com.example.okhttp.SingletonContext
+import com.example.okhttp.model.Entity.Flag
+import com.example.okhttp.model.Entity.Visa
 import org.xmlpull.v1.XmlPullParser
 
 class XmlManager {

--- a/app/src/main/java/com/example/okhttp/viewmodel/MainFragmentViewModel.kt
+++ b/app/src/main/java/com/example/okhttp/viewmodel/MainFragmentViewModel.kt
@@ -1,0 +1,15 @@
+package com.example.okhttp.viewmodel
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.example.okhttp.model.Entity.Flag
+import com.example.okhttp.model.XmlManager
+
+class MainFragmentViewModel : ViewModel() {
+    var flagList = MutableLiveData(listOf<Flag>())
+    var xmlManager = XmlManager()
+
+    fun getFlagList(region: XmlManager.Region) {
+        flagList.postValue(xmlManager.changeCountriesList(region))
+    }
+}


### PR DESCRIPTION
・対処内容
mvvmに変更に伴い、viewmodelの作成

・具体的な対処内容
view\Fragment\MainFragment.kt
onCreateView内から呼び出す以下を呼び出し、リストを取得する
```
private fun setupObserve() {
    viewModel.getFlagList(XmlManager.Region.Asia)

    viewModel.flagList.observe(viewLifecycleOwner) {
        adapter?.flagList = it
    }
}
```

viewModelからflagListを取得するように作成
viewmodel\MainFragmentViewModel.kt
```
class MainFragmentViewModel : ViewModel() {
    var flagList = MutableLiveData(listOf<Flag>())
    var xmlManager = XmlManager()

    fun getFlagList(region: XmlManager.Region) {
        flagList.postValue(xmlManager.changeCountriesList(region))
    }
}
```

・確認内容
動作に問題がないこと