### PR TITLE
Feature/replace viewmodel in detail visa fragment

### DIFF
--- a/app/src/main/java/com/example/okhttp/view/Fragment/DetailVisaFragment.kt
+++ b/app/src/main/java/com/example/okhttp/view/Fragment/DetailVisaFragment.kt
@@ -5,13 +5,14 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import com.example.okhttp.model.Entity.Flag
-import com.example.okhttp.model.XmlManager
+import androidx.fragment.app.viewModels
 import com.example.okhttp.databinding.FragmentDetailVisaBinding
+import com.example.okhttp.model.Entity.Flag
+import com.example.okhttp.viewmodel.DetailVisaFragmentViewModel
 
 class DetailVisaFragment : Fragment() {
     lateinit var binding: FragmentDetailVisaBinding
-    var xmlManager = XmlManager()
+    private val viewModel: DetailVisaFragmentViewModel by viewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -19,9 +20,11 @@ class DetailVisaFragment : Fragment() {
     ): View? {
         binding = FragmentDetailVisaBinding.inflate(inflater, container, false)
         val flag = arguments?.getSerializable("flag") as Flag
-        val data = xmlManager.changeVisaList(flag.id)
+        viewModel.getVisaData(flag.id)
 
-        binding.visaInfomation.text = data[0].content.replace(" +".toRegex(), "\n")
+        viewModel.visaData.observe(viewLifecycleOwner) {
+            binding.visaInfomation.text = it
+        }
 
         return binding.root
     }

--- a/app/src/main/java/com/example/okhttp/viewmodel/DetailVisaFragmentViewModel.kt
+++ b/app/src/main/java/com/example/okhttp/viewmodel/DetailVisaFragmentViewModel.kt
@@ -1,0 +1,16 @@
+package com.example.okhttp.viewmodel
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.example.okhttp.model.XmlManager
+
+class DetailVisaFragmentViewModel : ViewModel() {
+    var visaData = MutableLiveData<String>()
+    var xmlManager = XmlManager()
+
+    fun getVisaData(id: Int) {
+        val data = xmlManager.changeVisaList(id)
+        data[0].content.replace(" +".toRegex(), "\n")
+        visaData.postValue(data[0].content.replace(" +".toRegex(), "\n"))
+    }
+}


### PR DESCRIPTION
・対処内容
アプリの構成をMVCからMVVMに変更するため、viewmodelを作成

・具体的な対処内容
viewmodel\DetailVisaFragmentViewModel.kt
```
class DetailVisaFragmentViewModel : ViewModel() {
    var visaData = MutableLiveData<String>()
    var xmlManager = XmlManager()

    fun getVisaData(id: Int) {
        val data = xmlManager.changeVisaList(id)
        data[0].content.replace(" +".toRegex(), "\n")
        visaData.postValue(data[0].content.replace(" +".toRegex(), "\n"))
    }
}
```

・確認内容
動作に問題がないことなど