### PR TITLE
Feature/replace viewmodel in detailembassyfragment

### DIFF
--- a/app/src/main/java/com/example/okhttp/view/Fragment/DetailEmbassyFragment.kt
+++ b/app/src/main/java/com/example/okhttp/view/Fragment/DetailEmbassyFragment.kt
@@ -6,18 +6,21 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.example.okhttp.model.Entity.Flag
-import com.example.okhttp.model.ScrapingManager
-import com.example.okhttp.model.XmlManager
 import com.example.okhttp.adapter.CountriesDetailEmbassyAdapter
 import com.example.okhttp.databinding.FragmentDetailEmbassyBinding
+import com.example.okhttp.model.Entity.Embassy
+import com.example.okhttp.model.Entity.Flag
+import com.example.okhttp.model.ScrapingManager
+import com.example.okhttp.viewmodel.DetailEmbassyFragmentViewModel
 import kotlinx.coroutines.*
 
 class DetailEmbassyFragment : Fragment() {
     lateinit var binding: FragmentDetailEmbassyBinding
     private var adapter: CountriesDetailEmbassyAdapter? = null
     var scrapingManager = ScrapingManager()
+    private val viewModel: DetailEmbassyFragmentViewModel by viewModels()
 
     @OptIn(DelicateCoroutinesApi::class)
     override fun onCreateView(
@@ -30,17 +33,20 @@ class DetailEmbassyFragment : Fragment() {
         recyclerView.layoutManager = LinearLayoutManager(view?.context)
         recyclerView.adapter = adapter
         val flag = arguments?.getSerializable("flag") as Flag
-        val url = ScrapingManager.UrlCreate(XmlManager.Region.indexOf(flag.region), flag).mainUrl
-        GlobalScope.launch(Dispatchers.Main) {
-            changeList(url)
+        viewModel.getEmbassyData(flag)
+
+        viewModel.embassyData.observe(viewLifecycleOwner) {
+            GlobalScope.launch(Dispatchers.Main) {
+                changeList(it)
+            }
         }
+        
         return binding.root
     }
 
     @SuppressLint("NotifyDataSetChanged")
-    private suspend fun changeList(url: String) {
+    private suspend fun changeList(archive: MutableList<Embassy>) {
         withContext(Dispatchers.Main) {
-            val archive = scrapingManager.fetchUrl(url)
             adapter?.embassyList = archive
             adapter?.notifyDataSetChanged()
         }

--- a/app/src/main/java/com/example/okhttp/viewmodel/DetailEmbassyFragmentViewModel.kt
+++ b/app/src/main/java/com/example/okhttp/viewmodel/DetailEmbassyFragmentViewModel.kt
@@ -10,13 +10,13 @@ import com.example.okhttp.model.XmlManager
 import kotlinx.coroutines.launch
 
 class DetailEmbassyFragmentViewModel : ViewModel() {
-    var visaData = MutableLiveData<MutableList<Embassy>>()
+    var embassyData = MutableLiveData<MutableList<Embassy>>()
     private val scrapingManager = ScrapingManager()
 
     fun getEmbassyData(flag: Flag) {
         viewModelScope.launch {
             val url = ScrapingManager.UrlCreate(XmlManager.Region.indexOf(flag.region), flag).mainUrl
-            visaData.postValue(scrapingManager.fetchUrl(url))
+            embassyData.postValue(scrapingManager.fetchUrl(url))
         }
     }
 }

--- a/app/src/main/java/com/example/okhttp/viewmodel/DetailEmbassyFragmentViewModel.kt
+++ b/app/src/main/java/com/example/okhttp/viewmodel/DetailEmbassyFragmentViewModel.kt
@@ -1,0 +1,22 @@
+package com.example.okhttp.viewmodel
+
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.okhttp.model.Entity.Embassy
+import com.example.okhttp.model.Entity.Flag
+import com.example.okhttp.model.ScrapingManager
+import com.example.okhttp.model.XmlManager
+import kotlinx.coroutines.launch
+
+class DetailEmbassyFragmentViewModel : ViewModel() {
+    var visaData = MutableLiveData<MutableList<Embassy>>()
+    private val scrapingManager = ScrapingManager()
+
+    fun getEmbassyData(flag: Flag) {
+        viewModelScope.launch {
+            val url = ScrapingManager.UrlCreate(XmlManager.Region.indexOf(flag.region), flag).mainUrl
+            visaData.postValue(scrapingManager.fetchUrl(url))
+        }
+    }
+}


### PR DESCRIPTION
・対処内容
アプリの構成をMVCからMVVMに伴い、viewmodelを作成

・具体的な対処内容
viewmodel\DetailEmbassyFragmentViewModel.kt
```
class DetailEmbassyFragmentViewModel : ViewModel() {
    var embassyData = MutableLiveData<MutableList<Embassy>>()
    private val scrapingManager = ScrapingManager()

    fun getEmbassyData(flag: Flag) {
        viewModelScope.launch {
            val url = ScrapingManager.UrlCreate(XmlManager.Region.indexOf(flag.region), flag).mainUrl
            embassyData.postValue(scrapingManager.fetchUrl(url))
        }
    }
}
```

・確認内容
動作に問題がないことなど