### PR TITLE
Main画面から遷移した際のタブの値を保持するように修正

### DIFF
--- a/app/src/main/java/com/example/okhttp/view/Fragment/DetailFragment.kt
+++ b/app/src/main/java/com/example/okhttp/view/Fragment/DetailFragment.kt
@@ -34,7 +34,7 @@ class DetailFragment : Fragment() {
             }.attach()
 
             backButton.setOnClickListener {
-                requireActivity().onBackPressed()
+                requireActivity().supportFragmentManager.popBackStack()
             }
 
             collapsingToolBar.let {

--- a/app/src/main/java/com/example/okhttp/view/Fragment/MainFragment.kt
+++ b/app/src/main/java/com/example/okhttp/view/Fragment/MainFragment.kt
@@ -2,22 +2,19 @@ package com.example.okhttp.view.Fragment
 
 import android.annotation.SuppressLint
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.example.okhttp.model.Entity.Flag
-import com.example.okhttp.model.XmlManager
 import com.example.okhttp.R
 import com.example.okhttp.adapter.CountriesListAdapter
 import com.example.okhttp.databinding.FragmentMainBinding
+import com.example.okhttp.model.Entity.Flag
+import com.example.okhttp.model.XmlManager
 import com.example.okhttp.viewmodel.MainFragmentViewModel
 import com.google.android.material.tabs.TabLayout
-import org.xmlpull.v1.XmlPullParserException
-import java.io.IOException
 
 class MainFragment : Fragment() {
     private lateinit var binding: FragmentMainBinding
@@ -44,6 +41,7 @@ class MainFragment : Fragment() {
                     if (tab != null) {
                         viewModel.getFlagList(XmlManager.Region.indexOf(tab.position))
                         adapter?.flagList = viewModel.flagList.value!!
+                        viewModel.tabPosition.postValue(tab.position)
 
                         recyclerView.scrollToPosition(0)
                         adapter?.notifyDataSetChanged()
@@ -78,6 +76,14 @@ class MainFragment : Fragment() {
         )
 
         return binding.root
+    }
+
+    override fun onResume() {
+        super.onResume()
+
+        viewModel.tabPosition.observe(viewLifecycleOwner) {
+            binding.tabLayout.getTabAt(it)?.select()
+        }
     }
 
     private fun setupObserve() {

--- a/app/src/main/java/com/example/okhttp/viewmodel/MainFragmentViewModel.kt
+++ b/app/src/main/java/com/example/okhttp/viewmodel/MainFragmentViewModel.kt
@@ -7,7 +7,8 @@ import com.example.okhttp.model.XmlManager
 
 class MainFragmentViewModel : ViewModel() {
     var flagList = MutableLiveData(listOf<Flag>())
-    var xmlManager = XmlManager()
+    val xmlManager = XmlManager()
+    var tabPosition = MutableLiveData<Int>()
 
     fun getFlagList(region: XmlManager.Region) {
         flagList.postValue(xmlManager.changeCountriesList(region))


### PR DESCRIPTION
・対処内容
Main画面から遷移した際のタブの値を保持するように修正

・具体的な対処内容
view\Fragment\DetailFragment.kt 
37行目
`requireActivity().supportFragmentManager.popBackStack()`

view\Fragment\MainFragment.kt 
44行目
`viewModel.tabPosition.postValue(tab.position)`
81~87行目
```
    override fun onResume() {
        super.onResume()

        viewModel.tabPosition.observe(viewLifecycleOwner) {
            binding.tabLayout.getTabAt(it)?.select()
        }
    }
```

viewmodel\MainFragmentViewModel.kt
10,11行目
```
val xmlManager = XmlManager()
var tabPosition = MutableLiveData<Int>()
```

・確認内容
詳細画面から戻った際に、遷移前のタブが選択されていることを確認